### PR TITLE
Update index.html

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -30,7 +30,7 @@ layout: base
                     Anyone who has contributed to KnightOS is welcome to write a blog post about KnightOS. If you've made
                     a contribution and want to talk about it, simply write up a post and send a pull request to
                     <a href="https://github.com/KnightOS/knightos.org">github.com/KnightOS/knightos.org</a>. Want to write a
-                    post here but haven't contributed to the project? <a href="/contribute/">Get started here!</a>
+                    post here but haven't contributed to the project? <a href="/contributing/">Get started here!</a>
                 </div>
             {% endif %}
             


### PR DESCRIPTION
Info dialog box about writing blog posts for KnightOS linked to `knightos.org/contribute/`, when the actual location for the intended page is `knightos.org/contributing/`.
