### PR TITLE
Adds external links to TI website for easy identification

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,16 +9,16 @@ layout: base
             <div class="col-xs-12">
                 <div id="hero-calculator" class="pull-left hidden-xs">
                     <img id="hero-calculator-img" src="/img/calculator.png" alt="Try KnightOS" width="635" height="422">
-                    
+
                     <canvas width="385" height="256" id="screen"></canvas>
-                    
+
                     <div id="hero-calculator-text" class="hero-block">
                         <h3>Try KnightOS!</h3>
                         <p>This is a real calculator running the latest version of KnightOS. Use your arrow keys and F1-F5 to play with it.<br />
                         <span class="text-danger">This demo is a work-in-progress. It is slow and buggy.</span></p>
                     </div>
                 </div>
-                
+
                 <div id="hero-introduction" class="hero-block text-center pull-right clearfix">
                     <h1>KnightOS</h1>
                     <h4>An open-source OS for calculators</h4>
@@ -48,7 +48,7 @@ layout: base
             {% endfor %}
             <a href="/blog/" class="btn btn-primary bottom-link">Read More »</a>
         </div>
-        
+
         <div class="col-md-4">
             <h3>What is KnightOS?</h3>
             <p>
@@ -66,12 +66,17 @@ layout: base
             <h3>Can I use KnightOS?</h3>
             <p>
                 KnightOS will run on any upgradable Texas Instruments calculator based on the z80 CPU. This includes the
-                TI-73, TI-83+, TI-83+ Silver Edition, TI-84+, TI-84+ Silver Edition, and TI-84+ Color Silver Edition.
+                <a href="https://education.ti.com/en/us/products/calculators/graphing-calculators/ti-73-explorer/features/features-summary" target="_blank">TI-73</a>,
+                <a href="https://education.ti.com/en/us/products/calculators/graphing-calculators/ti-83-plus" target="_blank">TI-83+</a>,
+                TI-83+ Silver Edition,
+                <a href="https://education.ti.com/en/us/products/calculators/graphing-calculators/ti-84-plus" target="_blank">TI-84+</a>,
+                <a href="https://education.ti.com/en/us/products/calculators/graphing-calculators/ti-84-plus-silver-edition" target="_blank">TI-84+ Silver Edition</a>, and
+                <a href="https://education.ti.com/en/us/products/calculators/graphing-calculators/ti-84-plus-c-silver-edition" target="_blank">TI-84+ Color Silver Edition</a>.
                 You can also run it on the French variations of these calculators, or in an emulator.
             </p>
             <a href="/download/" class="btn btn-primary bottom-link">Get KnightOS »</a>
         </div>
-        
+
         <div class="col-md-4">
             <h3>Get Involved</h3>
             <p>The best thing about KnightOS, by far, is the open-source nature of it. KnightOS is built by a community


### PR DESCRIPTION
I wanted to help by adding external links to Texas Instruments website
so people could better identify the calculator models, since there's a
variety of them.

All those links are based on this page: https://education.ti.com/en/us/products#product=graphing-calculators

Thank you
