### PR TITLE
Fix example code in C tutorial

### DIFF
--- a/documentation/tutorials/getting-started-c/corelib.md
+++ b/documentation/tutorials/getting-started-c/corelib.md
@@ -53,7 +53,7 @@ void main(void) {
     SCREEN *screen;
 +   load_library("/lib/core");
     get_lcd_lock();
-    screen = screen_allocate();
+    get_keypad_lock();
 {% endhighlight %}
 
 Now that we have corelib loaded into memory, we can start to use the functions
@@ -65,7 +65,9 @@ around it.
 @@ -13,2 +14,4 @@ start:
 void main() {
     SCREEN *screen;
+    load_library("/lib/core");
     get_lcd_lock();
+    get_keypad_lock();
     screen = screen_allocate();
     screen_clear(screen);
 +   draw_window(screen, "C Demo", WIN_DEFAULTS);
@@ -87,6 +89,7 @@ void main(void) {
     SCREEN *screen;
     load_library("/lib/core");
     get_lcd_lock();
+    get_keypad_lock();
     screen = screen_allocate();
     screen_clear(screen);
     draw_window(screen, "C Demo", 0);

--- a/documentation/tutorials/getting-started-c/program.md
+++ b/documentation/tutorials/getting-started-c/program.md
@@ -64,6 +64,7 @@ convenience), we can go over how it works.
 void main() {
     SCREEN *screen;
     get_lcd_lock();
+    get_keypad_lock();
     screen = screen_allocate();
     screen_clear(screen);
     draw_string(screen, 0, 0, "Hello world!");
@@ -76,9 +77,10 @@ void main() {
 On KnightOS, your program has to cooperate with other running programs. Because of this, we
 manage the allocation of each part of the calculator so that your program gets
 along with the others. For this example, we need to reserve and allocate the screen (aka the
-LCD): 
+LCD) and the keypad:
 {% highlight c %}
 get_lcd_lock();
+get_keypad_lock();
 screen = screen_allocate();
 {% endhighlight %}
 


### PR DESCRIPTION
It won’t work without get_keypad_lock(). I’m not sure it really makes
sense to include it in program.md, but I opted for consistency with the
z80 tutorial.